### PR TITLE
Allow for custom materials

### DIFF
--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -116,7 +116,7 @@ pub trait App<T: 'static = ()> {
         Box::pin(async move { rend3::create_iad(None, None, None, None).await })
     }
 
-    fn create_base_rendergraph(&mut self, renderer: &Arc<Renderer>, spp: &ShaderPreProcessor) -> BaseRenderGraph {
+    fn create_base_rendergraph(&mut self, renderer: &Arc<Renderer>, spp: &mut ShaderPreProcessor) -> BaseRenderGraph {
         BaseRenderGraph::new(renderer, spp)
     }
 
@@ -224,7 +224,7 @@ pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_att
     let mut spp = rend3::ShaderPreProcessor::new();
     rend3_routine::builtin_shaders(&mut spp);
 
-    let base_rendergraph = app.create_base_rendergraph(&renderer, &spp);
+    let base_rendergraph = app.create_base_rendergraph(&renderer, &mut spp);
     let mut data_core = renderer.data_core.lock();
     let routines = Arc::new(DefaultRoutines {
         pbr: Mutex::new(rend3_routine::pbr::PbrRoutine::new(


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

## Description
Changed the mutability of the ShaderPreProcessor borrow in create_base_rendergraph so that custom materials are possible:
When wanting to use custom shaders, we need a mutable access to the preprocessor in order to construct routines as code such as we need to call `ShaderPreProcessor#add_shaders_embed` to be able to use them later on in `ShaderPreProcessor#render_shader`

Note: I don't know what your plans are with rend3-hp, if you want to keep it a best effort fork of rend3 or if you only want to maintain rend3 in the context of sharpview, in which case, I would understand that the PR isn't really useful.